### PR TITLE
Fix 3 failing object-formatting tests by forcing color output in non-TTY environments

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -94,9 +94,11 @@ mod json_formatter_tests {
 
     #[test]
     fn it_formats_an_object() {
+        colored::control::set_override(true);
         let input = "{\"name\": \"Nico\",\"foo\": \"bar\"}";
         let expected = "{\n  \u{1b}[1;95m\"name\"\u{1b}[0m: \"Nico\",\n  \u{1b}[1;95m\"foo\"\u{1b}[0m: \"bar\"\n}";
         let result = format(input);
+        colored::control::unset_override();
 
         assert_eq!(expected, result);
     }

--- a/src/nodes/object.rs
+++ b/src/nodes/object.rs
@@ -85,17 +85,20 @@ mod object_tests {
 
     #[test]
     fn it_formats_an_object() {
+        colored::control::set_override(true);
         let object = Object {
             members: vec![("member", Box::new(String { value: "value" }))],
         };
         let expected = "{\n  \u{1b}[1;95m\"member\"\u{1b}[0m: \"value\"\n}";
         let result = object.format_as_root();
+        colored::control::unset_override();
 
         assert_eq!(expected, result);
     }
 
     #[test]
     fn it_formats_a_multidimensional_object() {
+        colored::control::set_override(true);
         let first_level_object = Object {
             members: vec![("member", Box::new(String { value: "value" }))],
         };
@@ -108,6 +111,7 @@ mod object_tests {
         };
         let expected = "{\n  \u{1b}[1;95m\"member\"\u{1b}[0m: \"value\",\n  \u{1b}[1;95m\"number\"\u{1b}[0m: 2,\n  \u{1b}[1;95m\"child\"\u{1b}[0m: {\n    \u{1b}[1;95m\"member\"\u{1b}[0m: \"value\"\n  }\n}";
         let result = object.format_as_root();
+        colored::control::unset_override();
 
         assert_eq!(expected, result);
     }


### PR DESCRIPTION
The `colored` crate disables ANSI codes when stdout is not a TTY (as in test
runners). Tests that assert on colored key output now call
`colored::control::set_override(true)` before formatting and reset with
`unset_override()` after, so they reliably exercise the color code path