### PR TITLE
Fix 3 failing object-formatting tests in non-TTY environments

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -94,9 +94,11 @@ mod json_formatter_tests {
 
     #[test]
     fn it_formats_an_object() {
+        colored::control::set_override(true);
         let input = "{\"name\": \"Nico\",\"foo\": \"bar\"}";
         let expected = "{\n  \u{1b}[1;95m\"name\"\u{1b}[0m: \"Nico\",\n  \u{1b}[1;95m\"foo\"\u{1b}[0m: \"bar\"\n}";
         let result = format(input);
+        colored::control::unset_override();
 
         assert_eq!(expected, result);
     }

--- a/src/nodes/object.rs
+++ b/src/nodes/object.rs
@@ -85,17 +85,20 @@ mod object_tests {
 
     #[test]
     fn it_formats_an_object() {
+        colored::control::set_override(true);
         let object = Object {
             members: vec![("member", Box::new(String { value: "value" }))],
         };
         let expected = "{\n  \u{1b}[1;95m\"member\"\u{1b}[0m: \"value\"\n}";
         let result = object.format_as_root();
+        colored::control::unset_override();
 
         assert_eq!(expected, result);
     }
 
     #[test]
     fn it_formats_a_multidimensional_object() {
+        colored::control::set_override(true);
         let first_level_object = Object {
             members: vec![("member", Box::new(String { value: "value" }))],
         };
@@ -108,6 +111,7 @@ mod object_tests {
         };
         let expected = "{\n  \u{1b}[1;95m\"member\"\u{1b}[0m: \"value\",\n  \u{1b}[1;95m\"number\"\u{1b}[0m: 2,\n  \u{1b}[1;95m\"child\"\u{1b}[0m: {\n    \u{1b}[1;95m\"member\"\u{1b}[0m: \"value\"\n  }\n}";
         let result = object.format_as_root();
+        colored::control::unset_override();
 
         assert_eq!(expected, result);
     }


### PR DESCRIPTION
## Summary

- The `colored` crate disables ANSI codes when stdout is not a TTY (e.g. in test runners), causing the three object-formatting tests to fail because their expected strings included ANSI color codes.
- Added `colored::control::set_override(true)` before formatting and `unset_override()` after in each affected test to force color output regardless of environment.

## Tests affected

- `nodes::object::object_tests::it_formats_an_object`
- `nodes::object::object_tests::it_formats_a_multidimensional_object`
- `formatter::json_formatter_tests::it_formats_an_object`

## Test plan

- [ ] `cargo test` passes with 30/30 tests green

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHd1Nx228QwtR5sGowP7mN)_